### PR TITLE
Update to expose rank and score with multipliers applied

### DIFF
--- a/Plugin/GameData/LiveData.cs
+++ b/Plugin/GameData/LiveData.cs
@@ -24,6 +24,10 @@ namespace DataPuller.GameData
 
         //Score
         public static int Score { get; internal set; }
+        public static int ScoreWithMultipliers { get; internal set; }
+        public static int MaxScore { get; internal set; }
+        public static int MaxScoreWithMultipliers { get; internal set; }
+        public static string Rank { get; internal set; } = "";
         public static bool FullCombo { get; internal set; } = true;
         public static int Combo { get; internal set; }
         public static int Misses { get; internal set; }
@@ -45,6 +49,10 @@ namespace DataPuller.GameData
 
             //Score
             public int Score = LiveData.Score;
+            public int ScoreWithMultipliers = LiveData.ScoreWithMultipliers;
+            public int MaxScore = LiveData.MaxScore;
+            public int MaxScoreWithMultipliers = LiveData.MaxScoreWithMultipliers;
+            public string Rank = LiveData.Rank;
             public bool FullCombo = LiveData.FullCombo;
             public int Combo = LiveData.Combo;
             public int Misses = LiveData.Misses;
@@ -67,6 +75,10 @@ namespace DataPuller.GameData
             //Score Info
             FullCombo = true;
             Score = default;
+            ScoreWithMultipliers = default;
+            MaxScore = default;
+            MaxScoreWithMultipliers = default;
+            Rank = "";
             Combo = default;
             Misses = default;
             Accuracy = 100;

--- a/Plugin/MapEvents.cs
+++ b/Plugin/MapEvents.cs
@@ -123,6 +123,7 @@ namespace DataPuller
                 LiveData.InLevel = true;
                 scoreController = Resources.FindObjectsOfTypeAll<ScoreController>().LastOrDefault(x => x.isActiveAndEnabled);
                 scoreController.scoreDidChangeEvent += ScoreController_scoreDidChangeEvent;
+                scoreController.immediateMaxPossibleScoreDidChangeEvent += ScoreController_immediateMaxPossibleScoreDidChangeEvent;
 
                 audioTimeSyncController = Resources.FindObjectsOfTypeAll<AudioTimeSyncController>().LastOrDefault(x => x.isActiveAndEnabled);
                 PlayerData playerData = Resources.FindObjectsOfTypeAll<PlayerDataModel>().FirstOrDefault().playerData;
@@ -231,11 +232,29 @@ namespace DataPuller
             catch (Exception ex) { Logger.log.Error(ex); }
         }
 
-        private void ScoreController_scoreDidChangeEvent(int arg1, int arg2)
+        private void ScoreController_scoreDidChangeEvent(int beforeMultipliers, int afterMultipliers)
         {
-            LiveData.Score = arg1;
-            LiveData.Accuracy = arg1 / (float) scoreController.immediateMaxPossibleRawScore * 100;
-            LiveData.Send();
+            LiveData.Score = beforeMultipliers;
+            LiveData.ScoreWithMultipliers = afterMultipliers;
+            RecalculateRankAndAccuracy();
+        }
+
+        private void ScoreController_immediateMaxPossibleScoreDidChangeEvent(int rawScore, int modifiedScore)
+        {
+            LiveData.MaxScore = rawScore;
+            LiveData.MaxScoreWithMultipliers = modifiedScore;
+            RecalculateRankAndAccuracy();
+        }
+
+        private void RecalculateRankAndAccuracy()
+        {
+            if (LiveData.MaxScore != 0)
+            {
+                RankModel.Rank rank = RankModel.GetRankForScore(LiveData.Score, LiveData.ScoreWithMultipliers, LiveData.MaxScore, LiveData.MaxScoreWithMultipliers);
+                LiveData.Rank = RankModel.GetRankName(rank);
+                LiveData.Accuracy = LiveData.Score / (float) LiveData.MaxScore * 100;
+                LiveData.Send();
+            }
         }
 
         private void BSEvents_noteWasCut(NoteData arg1, NoteCutInfo nci, int arg3)


### PR DESCRIPTION
This commit updates the LiveData endpoint to expose a few more fields:

* `ScoreWithMultipliers` - Current score with multipliers (eg. No Fail)
  applied
* `MaxScore`
* `MaxScoreWithMultipliers`
* `Rank` - Current rank as a string (eg. `"SS"`). This is based on the
  score with multipliers, like the base game HUD.

It also updates the maximum score calculation to use the
`ScoreController.immediateMaxPossibleScoreDidChangeEvent` event instead
of `scoreController.immediateMaxPossibleRawScore`, which seems to be
consistently off by a small amount compared to the in-game HUD.

With these changes, an overlay can use the `ScoreWithMultipliers` and
`Rank` fields to display a UI with identical values to the in-game score
UI.