### PR TITLE
Use async IO to avoid blocking main thread

### DIFF
--- a/src/Client/LiveData.cs
+++ b/src/Client/LiveData.cs
@@ -11,7 +11,7 @@ namespace DataPuller.Client
         public static event Action<string> Update;
         public static void Send()
         {
-            Update(JsonConvert.SerializeObject(new JsonData(), Formatting.None));
+            Update?.Invoke(JsonConvert.SerializeObject(new JsonData(), Formatting.None));
             LastSend = DateTime.Now;
         }
 

--- a/src/Client/MapData.cs
+++ b/src/Client/MapData.cs
@@ -79,10 +79,10 @@ namespace DataPuller.Client
             public string CustomDifficultyLabel = MapData.CustomDifficultyLabel;
             public int BPM = MapData.BPM;
             public double NJS = MapData.NJS;
-            public Dictionary<string, bool> Modifiers = MapData.Modifiers;
+            public Dictionary<string, bool> Modifiers = MapData.Modifiers == null ? null : new Dictionary<string, bool>(MapData.Modifiers); // need to make a copy because MapData.Modifiers gets mutated
             public float ModifiersMultiplier = MapData.ModifiersMultiplier;
             public bool PracticeMode = MapData.PracticeMode;
-            public Dictionary<string, float> PracticeModeModifiers = MapData.PracticeModeModifiers;
+            public Dictionary<string, float> PracticeModeModifiers = MapData.PracticeModeModifiers == null ? null : new Dictionary<string, float>(MapData.PracticeModeModifiers);
             public double PP = MapData.PP;
             public double Star = MapData.Star;
 

--- a/src/Client/MapData.cs
+++ b/src/Client/MapData.cs
@@ -11,7 +11,7 @@ namespace DataPuller.Client
         public static void Send()
         {
             MapEvents.previousStaticData = new JsonData();
-            Update(JsonConvert.SerializeObject(MapEvents.previousStaticData, Formatting.None));
+            Update?.Invoke(JsonConvert.SerializeObject(MapEvents.previousStaticData, Formatting.None));
         }
 
         //Level

--- a/src/Server/Server.cs
+++ b/src/Server/Server.cs
@@ -42,7 +42,7 @@ namespace DataPuller.Server
                     {
                         promise.SetResult(null);
                     });
-                }, connectionClosed.Token);
+                }, connectionClosed.Token, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
             }
 
             protected override void OnClose(CloseEventArgs e)

--- a/src/Server/Server.cs
+++ b/src/Server/Server.cs
@@ -10,7 +10,7 @@ namespace DataPuller.Server
     class Server : /*IInitializable,*/ IDisposable
     {
         /*public static event Action<string> _SendError;
-        public static void SendError(string error) { _SendError(error); }*/
+        public static void SendError(string error) { _SendError?.Invoke(error); }*/
 
         private WebSocketServer webSocketServer = new WebSocketServer("ws://0.0.0.0:2946");
 
@@ -22,10 +22,6 @@ namespace DataPuller.Server
             webSocketServer.AddWebSocketService<LiveDataServer>("/BSDataPuller/LiveData");
             //webSocketServer.AddWebSocketService<ErrorServer>("/BSDataPuller/Error");
             webSocketServer.Start();
-
-            using (var ws = new WebSocket("ws://127.0.0.1:2946/BSDataPuller/MapData")) { while (!ws.IsAlive) { ws.Connect(); } ws.Close(); }
-            using (var ws = new WebSocket("ws://127.0.0.1:2946/BSDataPuller/LiveData")) { while (!ws.IsAlive) { ws.Connect(); } ws.Close(); }
-            //using (var ws = new WebSocket("ws://127.0.0.1:2946/BSDataPuller/Error")) { while (!ws.IsAlive) { ws.Connect(); } ws.Close(); }
         }
 
         private static bool MapDataServerInitalized = false;

--- a/src/Server/Server.cs
+++ b/src/Server/Server.cs
@@ -16,7 +16,7 @@ namespace DataPuller.Server
 
         private WebSocketServer webSocketServer = new WebSocketServer("ws://0.0.0.0:2946");
 
-        public Server(){ Initialize(); }
+        public Server() { Initialize(); }
 
         public void Initialize()
         {
@@ -31,12 +31,15 @@ namespace DataPuller.Server
             private Task readyToWrite = Task.CompletedTask;
             private readonly CancellationTokenSource connectionClosed = new CancellationTokenSource();
 
+            /// <summary>Queue data to send on the websocket in-order. This method is thread-safe.</summary>
             protected void QueuedSend(string data)
             {
                 var promise = new TaskCompletionSource<object>();
                 var oldReadyToWrite = Interlocked.Exchange(ref readyToWrite, promise.Task);
-                oldReadyToWrite.ContinueWith(t => {
-                    SendAsync(data, b => {
+                oldReadyToWrite.ContinueWith(t =>
+                {
+                    SendAsync(data, b =>
+                    {
                         promise.SetResult(null);
                     });
                 }, connectionClosed.Token);


### PR DESCRIPTION
This mod would call the WebSocketBehavior.Broadcast method on the main game thread, which did synchronous blocking IO and could stall the game for an arbitrary amount of time, especially if there were multiple connections to the websocket. I've measured the broadcast call sometimes taking 1-15 ms. This PR changes it so that asynchronous IO is used to write to the websocket, so that the game's main thread doesn't ever get stalled.

This PR also fixes a thread-safety issue: when websockets first connected, the OnOpen methods would unsafely read from objects that were written to from the main game thread. The code now uses `UnityMainThreadTaskScheduler.Factory.StartNew(() => ...).Result` to evaluate the expression reading the game info on the main game thread.

This PR fixes an issue where connections to /BSDataPuller/LiveData were always immediately closed, causing the client to have to constantly reopen the connection. There had been an unnecessary call to CloseSession left in. (I wonder if that call was present to work around a bug caused by the thread-safety issue I've fixed now.)

This PR also improves the code so that it doesn't need to connect to its own websockets on startup. (It seems like the code did this to work around the fact that it didn't null-check the event property.2)

This PR is very similar to my PR https://github.com/opl-/beatsaber-http-status/pull/60, which fixes the same set of issues that existed coincidentally in the HTTP Status mod.